### PR TITLE
Fix for `matches` resolving `document.body` at require time.

### DIFF
--- a/src/query/matches.js
+++ b/src/query/matches.js
@@ -2,21 +2,26 @@
 import canUseDOM from '../util/inDOM'
 import qsa from './querySelectorAll'
 
-let matches;
-if (canUseDOM) {
-  let body = document.body
-  let nativeMatch = body.matches
-                 || body.matchesSelector
-                 || body.webkitMatchesSelector
-                 || body.mozMatchesSelector
-                 || body.msMatchesSelector;
+let matchesCache;
 
-  matches = nativeMatch
-    ? (node, selector) => nativeMatch.call(node, selector)
-    : ie8MatchesSelector
+export default function matches(node, selector) {
+  if (!matchesCache && canUseDOM) {
+    let body = document.body
+    let nativeMatch = body.matches
+                   || body.matchesSelector
+                   || body.webkitMatchesSelector
+                   || body.mozMatchesSelector
+                   || body.msMatchesSelector;
+
+    matchesCache = nativeMatch
+      ? (node, selector) => nativeMatch.call(node, selector)
+      : ie8MatchesSelector
+  }
+
+  return matchesCache ?
+    matchesCache(node, selector) :
+    null;
 }
-
-export default matches
 
 function ie8MatchesSelector(node, selector) {
   var matches = qsa(node.document || node.ownerDocument, selector)


### PR DESCRIPTION
Delayed the resolution of `document.body` inside `matches` to the first call, instead of at require time. Before `DOMContentLoaded` has fired, `matches` will return `null`.